### PR TITLE
Define TaskStatus and remove references to task expired

### DIFF
--- a/src/vp/Tasks.js
+++ b/src/vp/Tasks.js
@@ -7,6 +7,9 @@ const DEFAULT_TASK_EXPIRY = '48h';
 const TaskType = {
   POLL: 'Poll',
 };
+const TaskStatus = {
+  COMPLETED: 'COMPLETED',
+};
 
 function createSimpleTask({
   name, taskExpiresAfter = DEFAULT_TASK_EXPIRY, externalSystemId, parameters,
@@ -33,8 +36,6 @@ function createPollingTask(options = {}) {
 }
 
 function isExpired(task) {
-  if (task.expired) return true;
-
   const expiresAtDate = new Date(task.expiresAt);
   return expiresAtDate < new Date();
 }
@@ -47,7 +48,7 @@ function nextRunTime(task) {
 function shouldRun(task) {
   return (
     task.type === TaskType.POLL
-    && !(task.status && task.status === 'COMPLETED')
+    && !(task.status && task.status === TaskStatus.COMPLETED)
     && nextRunTime(task) < new Date()
     && !isExpired(task)
   );
@@ -98,4 +99,5 @@ module.exports = {
   resolveTask,
   DEFAULT_TASK_EXPIRY,
   TaskType,
+  TaskStatus,
 };

--- a/test/unit/vp/Tasks.test.js
+++ b/test/unit/vp/Tasks.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const timestamp = require('unix-timestamp');
 
 const tasks = require('../../../src/vp/Tasks');
+
 const { TaskStatus } = tasks;
 
 describe('Tasks', () => {

--- a/test/unit/vp/Tasks.test.js
+++ b/test/unit/vp/Tasks.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const timestamp = require('unix-timestamp');
 
 const tasks = require('../../../src/vp/Tasks');
+const { TaskStatus } = tasks;
 
 describe('Tasks', () => {
   it('should create a simple task', () => {
@@ -28,13 +29,6 @@ describe('Tasks', () => {
 
     expect(tasks.isExpired(expiredTask)).to.be.true;
     expect(tasks.isExpired(unexpiredTask)).to.be.false;
-  });
-
-  it('should report expired tasks marked as expired', () => {
-    const expiredTask = tasks.createSimpleTask();
-    expiredTask.expired = true;
-
-    expect(tasks.isExpired(expiredTask)).to.be.true;
   });
 
   it('should create a polling task', () => {
@@ -76,7 +70,7 @@ describe('Tasks', () => {
   it('should not run a completed task', () => {
     const taskDueToRun = tasks.createPollingTask({ interval: '-1m' });
     const taskNotDueToRun = tasks.createPollingTask({ interval: '-1m' });
-    taskNotDueToRun.status = 'COMPLETED';
+    taskNotDueToRun.status = TaskStatus.COMPLETED;
 
     expect(tasks.shouldRun(taskDueToRun)).to.be.true;
     expect(tasks.shouldRun(taskNotDueToRun)).to.be.false;


### PR DESCRIPTION
Define _TaskStatus_ enum with the only supported status _COMPLETED_. This is to restrict the allowed values for Task status, considering the logic in the polling process check for the status field when filtering out tasks.

The `expired` field will be deprecated. It's actually never being set in Idv-toolkit and it's redundant as the `expiresAt` is being used. 