### PR TITLE
Add PlanManager interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ class MyUCAHandler extends ValidatingHandler {
 
 ## Plan Manager
 The IDV Commons library provides an abstract class, called `PlanManager`(`src/vp/PlanManager.js`), that defines the interface to implement the validation plan resolution.
-This class includes methods to list the plans supported by the IDV and to retrieve a plan given a credential item type.
+This class includes methods to list the plans supported by an IDV and to retrieve a plan given a credential item type.
 
 The IDV Toolkit supports implementing a custom Plan Manager for an IDV.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class MyUCAHandler extends ValidatingHandler {
 ```
 
 ## Plan Manager
-The IDV Commons library provides an ancestral handler, called `PlanManager`(`src/vp/PlanManager.js`), that defines the interface to implement the validation plan resolution.
+The IDV Commons library provides an abstract class, called `PlanManager`(`src/vp/PlanManager.js`), that defines the interface to implement the validation plan resolution.
 This class includes methods to list the plans supported by the IDV and to retrieve a plan given a credential item type.
 
 The IDV Toolkit supports implementing a custom Plan Manager for an IDV.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ class MyUCAHandler extends ValidatingHandler {
 }
 ```
 
+## Plan Manager
+The IDV Commons library provides an ancestral handler, called `PlanManager`(`src/vp/PlanManager.js`), that defines the interface to implement the validation plan resolution.
+This class includes methods to list the plans supported by the IDV and to retrieve a plan given a credential item type.
+
+The IDV Toolkit supports implementing a custom Plan Manager for an IDV.
+
 # Tasks
 In many cases, UCA validation may be handled by a service external to the IDV Toolkit, and may take more than a few seconds. 
 In this case, an external task can be added to the process state, that can be resolved later either via a notification or via polling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/idv-commons",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const Tasks = require('./vp/Tasks');
 const Context = require('./vp/Context');
 const Routes = require('./vp/Routes');
 const handlers = require('./vp/Handler');
+const PlanManager = require('./vp/PlanManager');
 
 module.exports = {
   CredentialRequestManager,
@@ -23,5 +24,6 @@ module.exports = {
   Tasks,
   Context,
   Routes,
+  PlanManager,
   ...handlers,
 };

--- a/src/vp/Handler.js
+++ b/src/vp/Handler.js
@@ -1,3 +1,4 @@
+
 /* eslint-disable class-methods-use-this, max-classes-per-file, no-unused-vars, no-console */
 const R = require('ramda');
 const { definitions, UserCollectableAttribute } = require('@identity.com/uca');

--- a/src/vp/Handler.js
+++ b/src/vp/Handler.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable class-methods-use-this, max-classes-per-file, no-unused-vars, no-console */
 const R = require('ramda');
 const { definitions, UserCollectableAttribute } = require('@identity.com/uca');

--- a/src/vp/PlanManager.js
+++ b/src/vp/PlanManager.js
@@ -1,0 +1,37 @@
+/* eslint-disable class-methods-use-this, no-unused-vars */
+
+const { MissingPlanError } = require('./InternalErrors');
+
+/**
+ * Abstract Plan Manager class.
+ * Defines the interface for a Plan Manager implementation.
+ * The Plan Manager class provides methods to be used in the (validation module) plan resolution.
+ * given a credential item name, and in converting a plan into a validation process.
+ *
+ * This class is designed to be subclassed and not used directly. When used directly
+ * it is a noop.
+ */
+class PlanManager {
+  constructor(config = {}) {
+    this.config = config;
+  }
+
+  /**
+   * Resolve to a plan given a credential item name
+   * @param name The credential item name
+   * @return {Promise<*>} The corresponding plan
+   */
+  async getPlan(name) {
+    throw new MissingPlanError(name);
+  }
+
+  /**
+   * List the plans supported by the IDV
+   * @return {Promise<Array.<string>>} The list of supported credential item names
+   */
+  async listPlans() {
+    return [];
+  }
+}
+
+module.exports = PlanManager;

--- a/test/unit/vp/PlanManager.test.js
+++ b/test/unit/vp/PlanManager.test.js
@@ -1,0 +1,28 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+const PlanManager = require('../../../src/vp/PlanManager');
+const { MissingPlanError } = require('../../../src/vp/InternalErrors');
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe('PlanManager', () => {
+  it('should instantiate PlanManager with no errors', () => {
+    expect(
+      () => (new PlanManager()),
+    ).not.to.throw();
+  });
+
+  it('should return a list of empty plans', async () => {
+    const planManager = new PlanManager();
+    const plans = await planManager.listPlans();
+    expect(plans).be.an('array').and.be.empty;
+  });
+
+  it('should throw an exception when getting a plan', async () => {
+    const planManager = new PlanManager();
+    const shouldBeRejected = planManager.getPlan('name');
+    expect(shouldBeRejected).to.be.rejectedWith(MissingPlanError);
+  });
+});


### PR DESCRIPTION
Adds an abstract class to the IDV Commons library - [`PlanManager`](src/vp/PlanManager.js) - that defines the interface to implement the validation plan resolution.

This class includes methods to list the plans supported by an IDV and to retrieve a plan given a credential item type.

This will be used by IDV Toolkit to support implementing a custom Plan Manager for an IDV.